### PR TITLE
Adds streaming functionality for chat

### DIFF
--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/OllamaAPI.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/OllamaAPI.java
@@ -448,12 +448,31 @@ public class OllamaAPI {
   * @throws InterruptedException in case the server is not reachable or network issues happen
    */
   public OllamaChatResult chat(OllamaChatRequestModel request)  throws OllamaBaseException, IOException, InterruptedException{
+    return chat(request);
+  }
+
+  /**
+   * Ask a question to a model using an {@link OllamaChatRequestModel}. This can be constructed using an {@link OllamaChatRequestBuilder}. 
+   * 
+   * Hint: the OllamaChatRequestModel#getStream() property is not implemented.
+   * 
+   * @param request request object to be sent to the server
+   * @param streamHandler callback handler to handle the last message from stream (caution: all previous messages from stream will be concatenated)
+   * @return 
+  * @throws OllamaBaseException any response code than 200 has been returned
+  * @throws IOException in case the responseStream can not be read
+  * @throws InterruptedException in case the server is not reachable or network issues happen
+   */
+  public OllamaChatResult chat(OllamaChatRequestModel request, OllamaStreamHandler streamHandler)  throws OllamaBaseException, IOException, InterruptedException{
     OllamaChatEndpointCaller requestCaller = new OllamaChatEndpointCaller(host, basicAuth, requestTimeoutSeconds, verbose);
-    //TODO: implement async way
-    if(request.isStream()){
-      throw new UnsupportedOperationException("Streamed chat responses are not implemented yet");
+    OllamaResult result;
+    if(streamHandler != null){
+      request.setStream(true);
+      result = requestCaller.call(request, streamHandler);
     }
-    OllamaResult result = requestCaller.generateSync(request);
+    else {
+     result = requestCaller.callSync(request);
+    }
     return new OllamaChatResult(result.getResponse(), result.getResponseTime(), result.getHttpStatusCode(), request.getMessages());
   }
 
@@ -470,7 +489,7 @@ public class OllamaAPI {
   private OllamaResult generateSyncForOllamaRequestModel(OllamaRequestModel ollamaRequestModel)
       throws OllamaBaseException, IOException, InterruptedException {
         OllamaGenerateEndpointCaller requestCaller = new OllamaGenerateEndpointCaller(host, basicAuth, requestTimeoutSeconds, verbose);
-        return requestCaller.generateSync(ollamaRequestModel);
+        return requestCaller.callSync(ollamaRequestModel);
   }
 
   /**

--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/OllamaStreamHandler.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/OllamaStreamHandler.java
@@ -1,0 +1,7 @@
+package io.github.amithkoujalgi.ollama4j.core;
+
+import java.util.function.Consumer;
+
+public interface OllamaStreamHandler extends Consumer<String>{
+    void accept(String message);
+}

--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/chat/OllamaChatStreamObserver.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/chat/OllamaChatStreamObserver.java
@@ -1,0 +1,34 @@
+package io.github.amithkoujalgi.ollama4j.core.models.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.github.amithkoujalgi.ollama4j.core.OllamaStreamHandler;
+import lombok.NonNull;
+
+public class OllamaChatStreamObserver {
+
+    private OllamaStreamHandler streamHandler;
+
+    private List<OllamaChatResponseModel> responseParts = new ArrayList<>();
+
+    private String message;
+
+    public OllamaChatStreamObserver(OllamaStreamHandler streamHandler) {
+        this.streamHandler = streamHandler;
+    }
+
+    public void notify(OllamaChatResponseModel currentResponsePart){
+        responseParts.add(currentResponsePart);
+        handleCurrentResponsePart(currentResponsePart);
+    }
+    
+    protected void handleCurrentResponsePart(OllamaChatResponseModel currentResponsePart){
+        List<@NonNull String> allResponsePartsByNow = responseParts.stream().map(r -> r.getMessage().getContent()).collect(Collectors.toList());
+        message = String.join("", allResponsePartsByNow);
+        streamHandler.accept(message);
+    }
+
+
+}

--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/request/OllamaChatEndpointCaller.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/request/OllamaChatEndpointCaller.java
@@ -1,12 +1,19 @@
 package io.github.amithkoujalgi.ollama4j.core.models.request;
 
+import java.io.IOException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.github.amithkoujalgi.ollama4j.core.OllamaStreamHandler;
+import io.github.amithkoujalgi.ollama4j.core.exceptions.OllamaBaseException;
 import io.github.amithkoujalgi.ollama4j.core.models.BasicAuth;
+import io.github.amithkoujalgi.ollama4j.core.models.OllamaResult;
 import io.github.amithkoujalgi.ollama4j.core.models.chat.OllamaChatResponseModel;
+import io.github.amithkoujalgi.ollama4j.core.models.chat.OllamaChatStreamObserver;
+import io.github.amithkoujalgi.ollama4j.core.utils.OllamaRequestBody;
 import io.github.amithkoujalgi.ollama4j.core.utils.Utils;
 
 /**
@@ -15,6 +22,8 @@ import io.github.amithkoujalgi.ollama4j.core.utils.Utils;
 public class OllamaChatEndpointCaller extends OllamaEndpointCaller{
 
     private static final Logger LOG = LoggerFactory.getLogger(OllamaChatEndpointCaller.class);
+
+    private OllamaChatStreamObserver streamObserver;
 
     public OllamaChatEndpointCaller(String host, BasicAuth basicAuth, long requestTimeoutSeconds, boolean verbose) {
         super(host, basicAuth, requestTimeoutSeconds, verbose);
@@ -27,18 +36,25 @@ public class OllamaChatEndpointCaller extends OllamaEndpointCaller{
 
     @Override
     protected boolean parseResponseAndAddToBuffer(String line, StringBuilder responseBuffer) {
-                try {
-                    OllamaChatResponseModel ollamaResponseModel = Utils.getObjectMapper().readValue(line, OllamaChatResponseModel.class);
-                    responseBuffer.append(ollamaResponseModel.getMessage().getContent());
-                    return ollamaResponseModel.isDone();
-                } catch (JsonProcessingException e) {
-                    LOG.error("Error parsing the Ollama chat response!",e);
-                    return true;
-                }         
+        try {
+            OllamaChatResponseModel ollamaResponseModel = Utils.getObjectMapper().readValue(line, OllamaChatResponseModel.class);
+            responseBuffer.append(ollamaResponseModel.getMessage().getContent());
+            if(streamObserver != null) {
+                streamObserver.notify(ollamaResponseModel);
+            }
+            return ollamaResponseModel.isDone();
+        } catch (JsonProcessingException e) {
+            LOG.error("Error parsing the Ollama chat response!",e);
+            return true;
+        }         
     }
 
-
+    public OllamaResult call(OllamaRequestBody body, OllamaStreamHandler streamHandler)
+            throws OllamaBaseException, IOException, InterruptedException {
+        streamObserver = new OllamaChatStreamObserver(streamHandler);
+        return super.callSync(body);
+    }
 
     
-
+ 
 }

--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/request/OllamaEndpointCaller.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/request/OllamaEndpointCaller.java
@@ -46,7 +46,7 @@ public abstract class OllamaEndpointCaller {
 
     protected abstract boolean parseResponseAndAddToBuffer(String line, StringBuilder responseBuffer);
 
-    
+
     /**
      * Calls the api server on the given host and endpoint suffix asynchronously, aka waiting for the response.
      * 
@@ -56,7 +56,7 @@ public abstract class OllamaEndpointCaller {
      * @throws IOException in case the responseStream can not be read
      * @throws InterruptedException in case the server is not reachable or network issues happen
      */
-    public OllamaResult generateSync(OllamaRequestBody body)  throws OllamaBaseException, IOException, InterruptedException{
+    public OllamaResult callSync(OllamaRequestBody body)  throws OllamaBaseException, IOException, InterruptedException{
 
         // Create Request
     long startTime = System.currentTimeMillis();


### PR DESCRIPTION
To provide better user experience for chat users, streaming should be enabled as for long responses client inactivity could provide negative impressions of using an AI chat.

Streaming the response reduces the amount of inactivity shown to the user significantly, especially when using models that are known to produce large assistant responses.